### PR TITLE
Upgrade to cats 0.8.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -92,7 +92,9 @@ lazy val commonSettings = Seq(
     Seq(dependencies.cats, dependencies.shapeless),
     dependencies.fs2,
     Seq(dependencies.scalatest, dependencies.scalacheck)
-  ).flatten
+  ).flatten,
+
+  addCompilerPlugin("com.milessabin" % "si2712fix-plugin" % "1.2.0" cross CrossVersion.full)
 )
 
 lazy val publishSettings = Seq(
@@ -104,11 +106,11 @@ lazy val publishSettings = Seq(
 
 lazy val dependencies = new {
 
-  val cats = "org.typelevel" %% "cats" % "0.7.2"
+  val cats = "org.typelevel" %% "cats" % "0.8.1"
   val shapeless = "com.chuusai" %% "shapeless" % "2.3.2"
   val fs2 = Seq(
-    "co.fs2" %% "fs2-core" % "0.9.1",
-    "co.fs2" %% "fs2-cats" % "0.1.0"
+    "co.fs2" %% "fs2-core" % "0.9.2",
+    "co.fs2" %% "fs2-cats" % "0.2.0"
   )
 
   val scalatest = "org.scalatest" %% "scalatest" % "3.0.0" % "test-internal"

--- a/src/main/scala/com/nokia/ntp/ct/persistence/persistenceApi.scala
+++ b/src/main/scala/com/nokia/ntp/ct/persistence/persistenceApi.scala
@@ -19,7 +19,6 @@ package persistence
 
 import akka.{ persistence => ap, typed => at }
 
-import cats.data.Xor
 import cats.free.Free
 
 /**
@@ -152,7 +151,7 @@ object ProcA {
   private[persistence] final case class Change[S](state: S) extends ProcA[S]
   private[persistence] final case class Same[S]() extends ProcA[S]
   private[persistence] final case class Stop[S]() extends ProcA[S]
-  private[persistence] final case class Attempt[A](proc: Proc[A]) extends ProcA[Xor[ProcException, A]]
+  private[persistence] final case class Attempt[A](proc: Proc[A]) extends ProcA[Either[ProcException, A]]
   private[persistence] final case class Fail[A](ex: ProcException) extends ProcA[A]
 
   private[persistence] def same[X]: Proc[X] =

--- a/src/main/scala/com/nokia/ntp/ct/persistence/testkit/TestInterpreter.scala
+++ b/src/main/scala/com/nokia/ntp/ct/persistence/testkit/TestInterpreter.scala
@@ -124,14 +124,14 @@ abstract class TestInterpreter[M, D, S](
         att.proc.foldMap(interpreter).transformF[Xss, Either[ProcException, a]] {
           case x @ Left(Error(ex, st)) => ex match {
             case ex: TypedPersistentActor.ActorStop =>
-              x.asInstanceOf[Either[SpecState, (InterpState, Either[ProcException, a])]]
+              x.copy()
             case ex: ProcException =>
               Right((st, Left(ex)))
             case ex: Any =>
               Right((st, Left(UnexpectedException(ex))))
           }
           case x @ Left(Stopped) =>
-            x.asInstanceOf[Either[SpecState, (InterpState, Either[ProcException, a])]]
+            x.copy()
           case Right((st, x)) =>
             Right((st, Right(x)))
         }

--- a/src/main/scala/com/nokia/ntp/ct/persistence/testkit/TestInterpreter.scala
+++ b/src/main/scala/com/nokia/ntp/ct/persistence/testkit/TestInterpreter.scala
@@ -23,7 +23,7 @@ import scala.util.Random
 
 import akka.{ typed => at }
 
-import cats.{ ~>, Eq, Monad }
+import cats.{ ~>, Eq }
 import cats.data.StateT
 import cats.implicits._
 
@@ -79,12 +79,6 @@ abstract class TestInterpreter[M, D, S](
 
   type Xss[X] = Either[SpecState, X]
   type TestProc[A] = StateT[Xss, InterpState, A]
-
-  //  // aargh ... SI-2712
-  //  implicit val xssMonad: Monad[Xss] =
-  //    catsStdInstancesForEither[SpecState]
-  implicit val tpMonad: Monad[TestProc] =
-    StateT.catsDataMonadForStateT[Xss, InterpState]
 
   val getInterpSt: TestProc[InterpState] =
     StateT.inspect[Xss, InterpState, InterpState](identity)

--- a/src/main/scala/com/nokia/ntp/ct/persistence/typedPersistentActor.scala
+++ b/src/main/scala/com/nokia/ntp/ct/persistence/typedPersistentActor.scala
@@ -22,7 +22,6 @@ import scala.util.control.ControlThrowable
 import akka.{ actor => au, persistence => ap, typed => at }
 
 import cats.~>
-import cats.data.Xor
 
 import fs2.Task
 import fs2.interop.cats._
@@ -313,9 +312,9 @@ private final class TypedPersistentActor[A, D, S](
         val inner = interpret(p)
         inner.attempt.flatMap {
           case Left(ex: ActorStop) => Task.fail(ex)
-          case Left(ex: ProcException) => Task.now(Xor.Left(ex))
-          case Left(ex) => Task.now(Xor.Left(UnexpectedException(ex)))
-          case Right(res) => Task.now(Xor.Right(res))
+          case Left(ex: ProcException) => Task.now(Left(ex))
+          case Left(ex) => Task.now(Left(UnexpectedException(ex)))
+          case Right(res) => Task.now(Right(res))
         }
       case ProcA.Fail(ex) =>
         Task.fail(ex)


### PR DESCRIPTION
* I still need to figure out how to correctly coerce the right types `TypesInterpreter`
* I also left some `si2712` comment in because I am not sure if I am doing it right.
* Lastly, I added Miles Sabin's compiler fix.

Most of the work was removing the `RecursiveTailRecM` instances since per https://github.com/typelevel/cats/pull/1370 it is now part of the instances