### PR TITLE
Add the capability to accept Futures

### DIFF
--- a/src/main/scala/com/nokia/ntp/ct/persistence/testkit/TestInterpreter.scala
+++ b/src/main/scala/com/nokia/ntp/ct/persistence/testkit/TestInterpreter.scala
@@ -24,11 +24,14 @@ import scala.util.Random
 import akka.{ typed => at }
 import akka.typed.scaladsl.Actor
 
-import cats.{ ~>, Eq }
+import cats.{ Eq, ~> }
 import cats.data.StateT
 import cats.implicits._
 
 import PersistentActor.PersistentActorImpl
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 
 /**
  * WIP testing framework for our persistence API.
@@ -143,6 +146,9 @@ abstract class TestInterpreter[M, D, S](
           case Right((st, x)) =>
             Right((st, Right(x)))
         }
+      case f: ProcA.FromFuture[X] =>
+        val s = Await.result(f.fut, Duration.Inf)
+        getActorSt.map(_ => s)
       case f: ProcA.Fail[X] =>
         getInterpSt.flatMap { st =>
           StateT.lift[Xss, InterpState, X](Left(Error(f.ex, st)))

--- a/src/main/scala/com/nokia/ntp/ct/persistence/typedPersistentActor.scala
+++ b/src/main/scala/com/nokia/ntp/ct/persistence/typedPersistentActor.scala
@@ -24,8 +24,10 @@ import akka.typed.scaladsl.Actor
 
 import cats.~>
 
-import fs2.Task
+import fs2.{ Strategy, Task }
 import fs2.interop.cats._
+
+import scala.concurrent.ExecutionContext
 
 /**
  * Combined `PersistentActor` and `ActorAdapter`.
@@ -330,6 +332,10 @@ private final class TypedPersistentActor[A, D, S](
         }
       case ProcA.Fail(ex) =>
         Task.fail(ex)
+      case f: ProcA.FromFuture[X] =>
+        implicit val S: Strategy = Strategy.fromExecutor(ctx.executionContext)
+        implicit val ec: ExecutionContext = ctx.executionContext
+        Task.fromFuture(f.fut)
     }
   }
 


### PR DESCRIPTION
So just wanted to get this on your radar for two reasons I had questions,
1) What should we do with Strategy from fs2, obviously this is not ideal the way it currently works, but figured it was easier to show than explain.
2) Should we expose them to fs2?  For instance, should we make it accept a fs2.task? And then for the `def future(f: Future[x]) = Task.fromFuture(...)`

PS, I wasn't sure how to solve the test interpreter since it doesn't target an asynchronous computation so I used an `Await.result`

Thoughts @dilation 